### PR TITLE
Peg MongoDB/MySQL Docker versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
   mysql-db:
-    image: mysql
+    image: mysql:8.0.28-debian
     deploy:
       resources:
         limits:
@@ -33,7 +33,7 @@ services:
     volumes:
       - mysqldata:/var/lib/mysql
   mongodb:
-    image: mongo:latest
+    image: mongo:5.0.6-focal
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Peg the version numbers of MongoDB and Mysql in docker-compose.yml
to the same versions which were used in the actual experiments.
This should make the experiment easier to reproduce.